### PR TITLE
Update Amazon Linux 2 AMI, Apache Kafka, CMAK and packer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Terraform module which creates Amazon Machine Images (AMI) for Camellia using Ha
 ```hcl
 module "camellia-image" {
   source = "ninthnails/camellia-image/aws"
-  version = "1.2.0"
+  version = "1.1.0"
   prefix = "camellia"
   packer_template = "aws-private.json"
   packer_instance_type = "t3a.micro"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Terraform module which creates Amazon Machine Images (AMI) for Camellia using HashiCorp Packer and AWS CodeBuild.
 
 ## Available Features
-* Apache Kafka version 2.3.1
+* Apache Kafka version 2.4.1
 * Based on Amazon Linux 2 with performance tuning 
 * Multi Availability Zone support
 * Support EBS, Instance Storage and root volume as storage types  
@@ -20,7 +20,7 @@ Terraform module which creates Amazon Machine Images (AMI) for Camellia using Ha
 ```hcl
 module "camellia-image" {
   source = "ninthnails/camellia-image/aws"
-  version = "1.1.0"
+  version = "1.2.0"
   prefix = "camellia"
   packer_template = "aws-private.json"
   packer_instance_type = "t3a.micro"

--- a/main.tf
+++ b/main.tf
@@ -309,7 +309,7 @@ phases:
     runtime-versions:
        java: corretto8
     commands:
-      - curl -sL -o packer.zip https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && unzip packer.zip
+      - curl -sL -o packer.zip https://releases.hashicorp.com/packer/1.6.2/packer_1.6.2_linux_amd64.zip && unzip packer.zip
       - pip3 -q install 'ansible~=2.7,<2.8'
   pre_build:
     commands:

--- a/packer/ansible/roles/cluster-manager/defaults/main.yaml
+++ b/packer/ansible/roles/cluster-manager/defaults/main.yaml
@@ -1,4 +1,4 @@
-cmak_version: 3.0.0.4
+cmak_version: 3.0.0.5
 cmak_dist_url: https://github.com/yahoo/CMAK/releases/download
 cmak_build_path: /tmp
 cmak_install_path: /opt/cmak

--- a/packer/ansible/roles/kafka/defaults/main.yaml
+++ b/packer/ansible/roles/kafka/defaults/main.yaml
@@ -1,4 +1,4 @@
-kafka_version: 2.3.1
+kafka_version: 2.4.1
 kafka_api_version: "{{ kafka_version[0:3] }}"
 kafka_dist_urls:
   - http://apache.mirrors.pair.com/kafka

--- a/packer/aws-default.json
+++ b/packer/aws-default.json
@@ -2,7 +2,7 @@
   "description": "Camellia Kafka",
   "variables": {
     "region": "us-east-1",
-    "kafka_version": "2.3.1",
+    "kafka_version": "2.4.1",
     "source_version": "LATEST",
     "build_id": "UNKNOWN",
     "build_number": "UNKNOWN",
@@ -20,8 +20,8 @@
           "virtualization-type": "hvm",
           "architecture": "x86_64",
           "ena-support": "true",
-          "name": "amzn2-ami-hvm-2.0.2019*",
-          "description": "Amazon Linux 2 AMI 2.0.2019* x86_64 HVM gp2",
+          "name": "amzn2-ami-hvm-2.0.2020*",
+          "description": "Amazon Linux 2 AMI 2.0.2020* x86_64 HVM gp2",
           "root-device-type": "ebs",
           "block-device-mapping.volume-type": "gp2"
         },

--- a/packer/aws-private.json
+++ b/packer/aws-private.json
@@ -2,7 +2,7 @@
   "description": "Camellia Kafka",
   "variables": {
     "region": "us-east-1",
-    "kafka_version": "2.3.1",
+    "kafka_version": "2.4.1",
     "source_version": "LATEST",
     "build_id": "UNKNOWN",
     "build_number": "UNKNOWN",
@@ -23,8 +23,8 @@
           "virtualization-type": "hvm",
           "architecture": "x86_64",
           "ena-support": "true",
-          "name": "amzn2-ami-hvm-2.0.2019*",
-          "description": "Amazon Linux 2 AMI 2.0.2019* x86_64 HVM gp2",
+          "name": "amzn2-ami-hvm-2.0.2020*",
+          "description": "Amazon Linux 2 AMI 2.0.2020* x86_64 HVM gp2",
           "root-device-type": "ebs",
           "block-device-mapping.volume-type": "gp2"
         },


### PR DESCRIPTION
* Update Amazon Linux 2 AMI 2019* -> 2020*
* Update Apache Kafka 2.3.1 -> 2.4.1
* Update packer 1.4.5 -> 1.6.2
* Update CMAK 3.0.0.4 -> 3.0.0.5